### PR TITLE
Created subroutine-subprogram action (rule 1231) similarly to function-subprogram action (R1223)

### DIFF
--- a/src/fortran/ofp/parser/FortranParserBase.g
+++ b/src/fortran/ofp/parser/FortranParserBase.g
@@ -240,7 +240,7 @@ declaration_construct
 // R208
 execution_part
 @after {
-    action.execution_part();
+	action.execution_part();
 }
 	:	executable_construct
 		( execution_part_construct )*
@@ -5665,11 +5665,16 @@ end_function_stmt
 // specification_part made non-optional to remove END ambiguity (as can 
 // be empty)
 subroutine_subprogram
+@init {
+    boolean hasExePart = false;
+    boolean hasIntSubProg = false;
+}
    :   subroutine_stmt
        specification_part
-       ( execution_part )?
-       ( internal_subprogram_part )?
+       ( execution_part { hasExePart=true; } )?
+       ( internal_subprogram_part { hasIntSubProg=true; } )?
        end_subroutine_stmt
+            { action.subroutine_subprogram(hasExePart, hasIntSubProg); }
    ;
 
 // R1232

--- a/src/fortran/ofp/parser/java/FortranParserActionPrint.java
+++ b/src/fortran/ofp/parser/java/FortranParserActionPrint.java
@@ -4928,6 +4928,22 @@ public class FortranParserActionPrint implements IFortranParserAction {
 		printRuleTrailer();
 	}
 
+	/**
+	 * R1231
+	 * subroutine_subprogram
+	 * 
+	 * @param hasExePart Flag specifying if optional execution_part was given.
+	 * @param hasIntSubProg Flag specifying if optional 
+	 * internal_subprogram_part was given.
+	 */
+	public void subroutine_subprogram(boolean hasExePart, 
+											  boolean hasIntSubProg) {
+		printRuleHeader(1231, "subroutine-subprogram");
+		printParameter(hasExePart, "hasExePart");
+		printParameter(hasIntSubProg, "hasIntSubProg");
+		printRuleTrailer();
+	}
+
 	/** R1232
 	 * subroutine_stmt__begin
 	 */

--- a/src/fortran/ofp/parser/java/IFortranParserAction.java
+++ b/src/fortran/ofp/parser/java/IFortranParserAction.java
@@ -4282,6 +4282,16 @@ public abstract interface IFortranParserAction {
     */
    public abstract void subroutine_stmt__begin();
 
+   /** R1231
+    * subroutine_subprogram
+    * 
+    * @param hasExePart Flag specifying if optional execution_part was given.
+    * @param hasIntSubProg Flag specifying if optional internal_subprogram_part
+    * was given.
+    */
+   public abstract void
+   subroutine_subprogram(boolean hasExePart, boolean hasIntSubProg);
+
    /** R1232
     * subroutine_stmt
     *   :   (label)? (t_prefix )? T_SUBROUTINE T_IDENT


### PR DESCRIPTION
Created a subroutine-subprogram action (R1231), similar to the function-subprogram action (R1223).
For this:
- Changed FortranParserBase.g grammar
- Added the subroutine_subprogram(...) method in IFortranParserAction.java
- Also added the method in FortranParserActionPrint.java

(+ an unfortunate whitespace change in FortranParserBase.g related to another modification that I will propose later)