### PR TITLE
Fixed a link in README.md that 404's

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The C action interfaces are currently provided by JNI.
 
 
 [Internal links]:#
-[INSTALL]: ./INSTALL
+[INSTALL]: ./INSTALL.md
 [src]: ./src
 [build]: ./build
 [tests]: ./tests


### PR DESCRIPTION
Made `[INSTALL]` in the `README.md` internal links link to `./INSTALL.md` instead of `./INSTALL`